### PR TITLE
Add dedicated blog page

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This repository contains a simple data-driven personal website for a software de
 
 The site is designed to look clean and minimal, similar to Apple's style. Blog posts are loaded dynamically from `posts.json` using JavaScript.
 
+All posts are listed on a dedicated [blog.html](blog.html) page as well as the blog section of the homepage.
+
 ## Adding a Blog Post
 
 1. Open `posts.json`.

--- a/blog.html
+++ b/blog.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Hey Anshul</title>
+    <title>Blog - Hey Anshul</title>
     <style>
         body {
             font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
@@ -29,9 +29,6 @@
             margin: 2rem auto;
             padding: 0 1rem;
         }
-        section {
-            margin-bottom: 3rem;
-        }
         #posts .post {
             margin-bottom: 2rem;
             padding-bottom: 1rem;
@@ -47,28 +44,15 @@
 </head>
 <body>
     <header>
-        <h1>Hey, I'm Anshul</h1>
+        <h1>Blog</h1>
         <nav>
-            <a href="#about">About</a>
-            <a href="blog.html">Blog</a>
-            <a href="#contact">Contact</a>
+            <a href="index.html">Home</a>
         </nav>
     </header>
 
     <main>
-        <section id="about">
-            <h2>About Me</h2>
-            <p>I am a software developer engineer in test. I enjoy exploring new technologies and sharing what I learn.</p>
-        </section>
-
-        <section id="blog">
-            <h2>Blog</h2>
+        <section>
             <div id="posts"></div>
-        </section>
-
-        <section id="contact">
-            <h2>Contact</h2>
-            <p>Reach me at <a href="mailto:example@example.com">example@example.com</a>.</p>
         </section>
     </main>
 


### PR DESCRIPTION
## Summary
- add a new `blog.html` page that lists all posts
- link to `blog.html` from the navigation
- document the blog page in the README

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6845d2e348888326b2df93f7b57a84ba